### PR TITLE
Composer needs a vendor/package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zip-payment-magento-1-extension",
+    "name": "zip-payment/magento-1-extension",
     "description": "Zip Payment Extension for Magento 1",
     "version": "2.0.0",
     "scripts": {


### PR DESCRIPTION
Deprecation warning: require.zip-payment-magento-1-extension is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*". Make sure you fix this as Composer 2.0 will error.