### PR TITLE
Fixing the autoloader issue in M1 when block did not initial the Zip lib

### DIFF
--- a/app/code/community/Zip/Payment/Block/Method/Form.php
+++ b/app/code/community/Zip/Payment/Block/Method/Form.php
@@ -15,6 +15,9 @@ class Zip_Payment_Block_Method_Form extends Mage_Payment_Block_Form
     protected function _construct()
     {
         parent::_construct();
+        if (!class_exists('\Zip\Model\CurrencyUtil')) {
+            include_once Mage::getBaseDir('lib') . DS . 'Zip' . DS . 'autoload.php';
+        }
 
         $this->setTemplate($this->_template);
         $this->setMethodLabelAfterHtml($this->getMethodLabelHtml());


### PR DESCRIPTION
M1 never autoload all classes in lib