### PR TITLE
Fix class not found error on checkout page

### DIFF
--- a/app/code/community/Zip/Payment/Helper/Data.php
+++ b/app/code/community/Zip/Payment/Helper/Data.php
@@ -9,6 +9,10 @@
 
 class Zip_Payment_Helper_Data extends Mage_Core_Helper_Abstract
 {
+    public function __construct()
+    {
+        include_once Mage::getBaseDir('lib') . DS . 'Zip' . DS . 'autoload.php';
+    }
 
     /**
      * get config model


### PR DESCRIPTION
Class Zip\Model\CurrencyUtil not found error from isRedirectCheckoutDisplayModel
function when called from Block/Checkout/Script.php.

Fix by including autoload.php in the Helper constructor like in other parts of the project.